### PR TITLE
(Documentation) Add example of building a Solution File

### DIFF
--- a/src/psbuild.psm1
+++ b/src/psbuild.psm1
@@ -95,6 +95,8 @@ function Set-MSBuild{
 
     This will accept the pipeline value as well.
 
+    This will accept either a Visual Studio Project File, or a Visual Studio Solution File (*.sln)
+
 .PARAMETER extraArgs
     You can use this to pass in additional parameters to msbuild.exe. This can be
     one of these types:
@@ -150,6 +152,10 @@ function Set-MSBuild{
 .EXAMPLE
     Invoke-MSBuild C:\temp\msbuild\msbuild.proj
     Shows how you can build a project.
+
+.EXAMPLE
+    Invoke-MSBuild C:\temp\msbuild\msbuild.sln
+    Shows how you can build a solution.
 
 .EXAMPLE
     Invoke-MSBuild C:\temp\msbuild\msbuild.proj -configuration Release -visualStudioVersion 12.0


### PR DESCRIPTION
- While trying out psbuild for the first time, I noticed that the documentation didn't include an example of passing a *.sln file
- Felt that this was required, as it is a common use case
