### PR TITLE
Add support for building without supplying a sln/proj.

### DIFF
--- a/src/psbuild.psm1
+++ b/src/psbuild.psm1
@@ -197,7 +197,7 @@ function Invoke-MSBuild{
         DefaultParameterSetName ='build')]
     param(
         [Parameter(ParameterSetName='build',Position=1,ValueFromPipeline=$true)]
-        [Parameter(ParameterSetName='debugMode',Position=1,ValueFromPipeline=$true)]
+        [Parameter(ParameterSetName='debugMode',Mandatory=$true,Position=1,ValueFromPipeline=$true)]
         [Parameter(ParameterSetName='preprocess',Position=1,ValueFromPipeline=$true)]
         [alias('proj')]
         $projectsToBuild,


### PR DESCRIPTION
This allows the normal msbuild behaviour, which looks in the current directory for a single item to build (see #41).

I've done some basic manual testing of this; and it seems to behave behave as expected; but I'm not sure if there might be any knock-on effects. I noticed there was a test.ps1 in the folder; but it's not clear to me how it works (nor does it look like it's testing much).

If you think this breaks anything. let me know and I'll investigate.
