### PR TITLE
Fixing issue with LocalSystem account and nuget. #72

### DIFF
--- a/src/GetPSBuild.ps1
+++ b/src/GetPSBuild.ps1
@@ -1,7 +1,7 @@
 ﻿[cmdletbinding()]
 param(
     $versionToInstall = '1.1.4-beta',
-    $toolsDir = ("$env:temp\LigerShark\psbuild\"),
+    $appDataDir = ("$env:LOCALAPPDATA\LigerShark\psbuild\"),
     $nugetDownloadUrl = 'http://nuget.org/nuget.exe',
     $nugetSource = 'https://www.nuget.org/api/v2/'
 )
@@ -89,7 +89,7 @@ Or visit http://msbuildbook.com/psbuild
 function Get-Nuget{
     [cmdletbinding()]
     param(
-        $toolsDir = $Script:toolsDir,
+        $toolsDir = $appDataDir,
         $nugetDownloadUrl = 'http://nuget.org/nuget.exe'
     )
     process{
@@ -142,7 +142,7 @@ function Invoke-CommandString{
 function GetPsBuildPsm1{
     [cmdletbinding()]
     param(
-        $toolsDir = $script:toolsDir,
+        $toolsDir = $appDataDir,
         $nugetDownloadUrl = 'http://nuget.org/nuget.exe'
     )
     process{
@@ -180,5 +180,22 @@ function GetPsBuildPsm1{
         $psbuildPsm1
     }
 }
+
+function Repair-ToolsDir
+{
+    [CmdletBinding()]
+    param($toolsDir = $appDataDir)
+
+    $systemDir = [Environment]::GetFolderPath('System')
+    if ($toolsDir.StartsWith($systemDir) -and ($PSVersionTable.CLRVersion.Major -ge 4))
+    {
+        $sysWowDir = [Environment]::GetFolderPath('SystemX86')
+        $toolsDir = $toolsDir.Replace($systemDir, $sysWowDir)
+    }
+
+    $toolsDir
+}
+
+$appDataDir = Repair-ToolsDir $appDataDir
 
 Install-PSBuild


### PR DESCRIPTION
Hi, I've fixed 2 issues at once.
- looks like the `$Script` scope isn't available (not defined) when running script via `Invoke-Expression (iex)`, so I just renamed vars.
- `NuGet.exe` has troubles running from the `Windows\System` folder, but it's OK to run from the `Windows\SysWOW64` folder, so I've also fixed that.

p.s. nuget issue has a little trails on the Internet. I've found the only report:  https://connect.microsoft.com/PowerShell/feedback/details/922914/wmf-5-may-preview-powershellget-nuget-exe-wont-launch-when-running-as-system